### PR TITLE
Fixing wallpaper's delete button functionality

### DIFF
--- a/a2n.blur/contents/ui/config.qml
+++ b/a2n.blur/contents/ui/config.qml
@@ -68,7 +68,7 @@ ColumnLayout {
     }
 
     function saveConfig() {
-        if (configDialog.currentWallpaper === "org.kde.image") {
+        if (configDialog.currentWallpaper === "a2n.blur") {
             imageWallpaper.wallpaperModel.commitAddition();
             imageWallpaper.wallpaperModel.commitDeletion();
         }


### PR DESCRIPTION
Marking a wallpaper for deletion and clicking apply doesn't delete the wallpaper, so this commit fixes it