### PR TITLE
Fix blank thumbnails and broken image selection (wrong model roles)

### DIFF
--- a/a2n.blur/contents/ui/ThumbnailsComponent.qml
+++ b/a2n.blur/contents/ui/ThumbnailsComponent.qml
@@ -89,7 +89,6 @@ Item {
 
                 framedView: false
 
-
                 function resetCurrentIndex() {
                     //that min is needed as the module will be populated in an async way
                     //and only on demand so we can't ensure it already exists
@@ -109,7 +108,6 @@ Item {
 
                 view.delegate: WallpaperDelegate {
                     color: cfg_Color
-                    previewSize: Qt.size(thumbnailsComponent.screenSize.width / 8, thumbnailsComponent.screenSize.height / 8)
                 }
             }
         }

--- a/a2n.blur/contents/ui/WallpaperDelegate.qml
+++ b/a2n.blur/contents/ui/WallpaperDelegate.qml
@@ -17,7 +17,6 @@ KCM.GridDelegate {
   id: wallpaperDelegate
 
   property alias color: backgroundRect.color
-  property alias previewSize: previewImage.sourceSize
   opacity: model.pendingDeletion ? 0.5 : 1
   scale: index, 1 // Workaround for https://bugreports.qt.io/browse/QTBUG-107458
 
@@ -63,7 +62,7 @@ thumbnail: Rectangle {
     width: Kirigami.Units.iconSizes.large
     height: width
     source: "view-preview"
-    visible: previewImage.status != Image.Ready
+    visible: model.screenshot === null
   }
 
   FastBlur {
@@ -71,23 +70,41 @@ thumbnail: Rectangle {
     visible: cfg_Blur
     anchors.fill: parent
     radius: 4
-    source: Image {
-      asynchronous: true
-      cache: false
-      fillMode: Image.PreserveAspectCrop
-      source: fastBlur.visible ? previewImage.source : ""
-      sourceSize: previewImage.sourceSize
-      visible: false
-    }
+    source: previewContainer
   }
 
-  Image {
-    id: previewImage
+  // previewImage (QPixmapItem, a QQuickPaintedItem) must not be used directly as an
+  // effect/layer source: KDE#47/KDE#48 showed QQuickPaintedItem's texture provider
+  // is unreliable as a ShaderEffectSource on KDE Plasma 6.4+ ("Unable to assign
+  // QPixmapItem to QUrl" / "textureProvider: can only be queried on the rendering
+  // thread of an exposed window"). Wrap it in a plain Item and layer/source from
+  // that instead.
+  Item {
+    id: previewContainer
     anchors.fill: parent
-    asynchronous: true
-    cache: false
-    fillMode: cfg_FillMode
-    source: model.preview || ""
+
+    QPixmapItem {
+      id: previewImage
+      anchors.fill: parent
+      smooth: true
+      pixmap: model.screenshot
+      fillMode: {
+        if (cfg_FillMode === Image.Stretch) {
+          return QPixmapItem.Stretch;
+        } else if (cfg_FillMode === Image.PreserveAspectFit) {
+          return QPixmapItem.PreserveAspectFit;
+        } else if (cfg_FillMode === Image.PreserveAspectCrop) {
+          return QPixmapItem.PreserveAspectCrop;
+        } else if (cfg_FillMode === Image.Tile) {
+          return QPixmapItem.Tile;
+        } else if (cfg_FillMode === Image.TileVertically) {
+          return QPixmapItem.TileVertically;
+        } else if (cfg_FillMode === Image.TileHorizontally) {
+          return QPixmapItem.TileHorizontally;
+        }
+        return QPixmapItem.PreserveAspectFit;
+      }
+    }
 
     layer.enabled: cfg_ActiveBlur
 
@@ -95,14 +112,6 @@ thumbnail: Rectangle {
       visible: cfg_ActiveBlur
       anchors.fill: parent
       radius: wallpaperDelegate.hovered ? cfg_BlurRadius : 0
-      source: Image {
-        asynchronous: true
-        cache: false
-        fillMode: Image.PreserveAspectCrop
-        source: previewImage.source
-        sourceSize: previewImage.sourceSize
-        anchors.fill: parent
-      }
 
       // animate the blur apparition
       Behavior on radius {
@@ -115,8 +124,8 @@ thumbnail: Rectangle {
 
   ColorOverlay {
     id: activeColorOverlay
-    anchors.fill: previewImage
-    source: previewImage
+    anchors.fill: previewContainer
+    source: previewContainer
     visible: cfg_ActiveColor
     color: cfg_ActiveColorColor
     opacity: (cfg_ActiveColor && wallpaperDelegate.hovered) ? cfg_ActiveColorTransparency / 100 : 0
@@ -154,7 +163,7 @@ Behavior on opacity {
 
 onClicked: {
   if (!cfg_IsSlideshow) {
-    cfg_Image = model.source;
+    cfg_Image = model.packageName || model.path;
     if (typeof wallpaper !== "undefined") {
       wallpaper.configuration.PreviewImage = cfg_Image;
     }

--- a/a2n.blur/contents/ui/config.qml
+++ b/a2n.blur/contents/ui/config.qml
@@ -48,13 +48,21 @@ ColumnLayout {
 
   // custom property for the active blur effect
   property alias cfg_ActiveBlur: activeBlurRadioButton.checked
+  property bool cfg_ActiveBlurDefault: true
   property int cfg_AnimationDuration: 400
+  property int cfg_AnimationDurationDefault: 400
   property int cfg_AnimationDurationColor: 400
+  property int cfg_AnimationDurationColorDefault: 400
   property int cfg_BlurRadius: 40
+  property int cfg_BlurRadiusDefault: 40
   property alias cfg_ActiveColor: activeColorRadioButton.checked
+  property bool cfg_ActiveColorDefault: false
   property int cfg_ActiveColorTransparency: 20
+  property int cfg_ActiveColorTransparencyDefault: 20
   property alias cfg_ActiveColorColor: activeColorColorButton.color
+  property color cfg_ActiveColorColorDefault: "#000"
   property alias cfg_IsSlideshow: activeSlideshowRadioButton.checked
+  property bool cfg_IsSlideshowDefault: false
 
   signal configurationChanged()
   /**


### PR DESCRIPTION
Fixes #58

## Problem

Every wallpaper thumbnail in the config grid shows the placeholder icon instead of the actual image, and clicking a thumbnail throws `Cannot assign [undefined] to QString` and doesn't select it.

Reproduced on a fresh open of System Settings → Wallpaper:
```
WallpaperDelegate.qml:157: Error: Cannot assign [undefined] to QString
WallpaperDelegate.qml:157: Error: Cannot assign [undefined] to QString
WallpaperDelegate.qml:157: Error: Cannot assign [undefined] to QString
WallpaperDelegate.qml:157: Error: Cannot assign [undefined] to QString
```
which matches what other users have posted on #58 itself.

## Root cause

The image list model (shared with `org.kde.image`, see `wallpapers/image/plugin/model/abstractimagelistmodel.cpp` in plasma-workspace) only registers these QML roles:

`display`, `author`, `screenshot`, `path`, `packageName`, `removable`, `pendingDeletion`, `checked`

There is no `preview` role and no `source` role. `WallpaperDelegate.qml` reads `model.preview` for the thumbnail image and `model.source` in `onClicked` — both always `undefined`. Since the `Image`'s `source` binds to `""`, its `status` never leaves `Null`, so the placeholder icon shows forever. Assigning `undefined` to `cfg_Image` (a `property string`) is what throws the error above and leaves the selection unchanged.

## Fix

- Since `screenshot` is a `QPixmap` (not a URL), switch the thumbnail from `Image` to `QPixmapItem`, matching how `org.kde.image` renders it, with a `fillMode` mapping from the existing `cfg_FillMode` (`Image.*`) enum values already used elsewhere in this file. Restore `model.packageName || model.path` in `onClicked`, matching `org.kde.image`'s own handler.
- `QPixmapItem` (a `QQuickPaintedItem`) can't be used directly as a `layer`/effect source — querying its texture provider that way is unreliable and throws:
  ```
  WallpaperDelegate.qml:114:21: Unable to assign QPixmapItem to QUrl
  QQuickPaintedItem::textureProvider: can only be queried on the rendering thread of an exposed window
  ```
  as seen on #47 and #48. The active-blur hover effect, the letterbox background blur, and the dim `ColorOverlay` are now applied to a plain wrapping `Item` around the `QPixmapItem` instead of the `QPixmapItem` itself, so they render from a normal FBO rather than the painted item's own texture provider.
- Drop the `previewSize` alias to `Image.sourceSize`, which `QPixmapItem` doesn't have.
- `config.qml`'s custom `cfg_ActiveBlur`/`cfg_BlurRadius`/`cfg_ActiveColor`/... properties had no matching `cfg_*Default` companions, which `kcm_wallpaper`'s generic config loader assigns for every kcfg entry on load. Added the missing `Default` properties to stop `Cannot assign to non-existent property` on every open.

## Testing

Verified against a live `systemsettings kcm_wallpaper` process on Plasma 6.3.6. Before the fix, opening the Wallpaper page logged (beyond the generic warnings any wallpaper plugin produces):
```
Cannot assign to non-existent property "cfg_IsSlideshowDefault"
Cannot assign to non-existent property "cfg_ActiveBlurDefault"
Cannot assign to non-existent property "cfg_BlurRadiusDefault"
Cannot assign to non-existent property "cfg_ActiveColorDefault"
Cannot assign to non-existent property "cfg_ActiveColorTransparencyDefault"
Cannot assign to non-existent property "cfg_ActiveColorColorDefault"
Cannot assign to non-existent property "cfg_AnimationDurationDefault"
Cannot assign to non-existent property "cfg_AnimationDurationColorDefault"
```
After the fix, the same page loads with none of the above — the only remaining lines are generic shell warnings also present when loading the stock `org.kde.image` plugin (unrelated to this plugin, e.g. `Cannot assign to non-existent property "screen"` from `kcm_wallpaper`'s own `main.qml`). Thumbnails render correctly and clicking selects the image with no console errors. Confirmed on real hardware as well — thumbnails render, Apply works, and no regressions from #47/#48 (active-blur hover preview still works correctly).