### PR TITLE
Guard saveConfig() against null wallpaperConfiguration

### DIFF
--- a/a2n.blur/contents/ui/config.qml
+++ b/a2n.blur/contents/ui/config.qml
@@ -73,7 +73,9 @@ ColumnLayout {
       imageWallpaper.wallpaperModel.commitAddition();
       imageWallpaper.wallpaperModel.commitDeletion();
     }
-    wallpaperConfiguration.PreviewImage = "null"; // internal, no need to save to file
+    if (wallpaperConfiguration) {
+      wallpaperConfiguration.PreviewImage = "null"; // internal, no need to save to file
+    }
   }
 
   function openChooserDialog() {


### PR DESCRIPTION
## Problem

Opening the Wallpaper page via System Settings (rather than the desktop's own "Configure Desktop and Wallpaper") and clicking Apply throws:
```
config.qml:76: TypeError: Value is null and could not be converted to an object
```

## Root cause

```qml
property var wallpaperConfiguration: wallpaper.configuration
```
`wallpaper` is a global object only injected when the config UI is opened through the desktop's own wallpaper containment. When the config module is opened directly, `wallpaper.configuration` resolves to `null`. `saveConfig()` writes to `wallpaperConfiguration.PreviewImage` unguarded, so it throws as soon as settings are saved.

Every other place this file touches `wallpaperConfiguration` already guards it first (`Component.onDestruction`), matching the identical pattern in `org.kde.image`'s own `config.qml`. `saveConfig()` was the one call site that never got it.

## Fix

```qml
if (wallpaperConfiguration) {
  wallpaperConfiguration.PreviewImage = "null"; // internal, no need to save to file
}
```

## Testing

Reproduced the exact error text in isolation with a minimal `qmltestrunner` case calling the unguarded assignment against a null `wallpaperConfiguration`, confirmed it matches `TypeError: Value is null and could not be converted to an object`, and confirmed the guarded version doesn't throw under the same condition. The guard only skips the write when there's no live wallpaper object to begin with, so it can't leave a stale preview behind and doesn't change behavior at all when `wallpaperConfiguration` is valid.